### PR TITLE
Fix strictness of query params

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -117,7 +117,7 @@ type _CreateFetch<OP, Q = never> = [Q] extends [never]
 
 export type CreateFetch<M, OP> = M extends 'post' | 'put' | 'patch' | 'delete'
   ? OP extends { parameters: { query: infer Q } }
-    ? _CreateFetch<OP, { [K in keyof Q]: true | 1 }>
+    ? _CreateFetch<OP, { [K in keyof Q]-?: true | 1 }>
     : _CreateFetch<OP>
   : _CreateFetch<OP>
 

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -86,7 +86,7 @@ describe('fetch', () => {
       const fun = fetcher
         .path('/bodyquery/{id}')
         .method(method)
-        .create({ scalar: 1 })
+        .create({ scalar: 1, optional: 1 })
 
       const { data } = await fun({
         id: 1,
@@ -235,7 +235,7 @@ describe('fetch', () => {
     const fun = fetcher
       .path('/bodyquery/{id}')
       .method('post')
-      .create({ scalar: 1 })
+      .create({ scalar: 1, optional: 1 })
 
     const captured = { url: '', body: '' }
 

--- a/test/infer.test.ts
+++ b/test/infer.test.ts
@@ -9,6 +9,7 @@ import {
   OpReturnType,
   TypedFetch,
 } from '../src'
+import { paths } from './paths'
 import { paths as paths2 } from './examples/stripe-openapi2'
 import { paths as paths3 } from './examples/stripe-openapi3'
 
@@ -40,6 +41,23 @@ interface Openapi3 {
 type Same<A, B> = A extends B ? (B extends A ? true : false) : false
 
 describe('infer', () => {
+  it('queryParams', () => {
+    const fetcher = Fetcher.for<paths>()
+
+    fetcher
+      .path('/bodyquery/{id}')
+      .method('post')
+      // @ts-expect-error // Missing the optional param is wrong
+      .create({ scalar: 1 })
+
+    fetcher
+      .path('/bodyquery/{id}')
+      .method('post')
+      .create({ scalar: 1, optional: 1 })
+
+    expect(true).toBe(true)
+  })
+
   it('argument', () => {
     const same: Same<Openapi2['Argument'], Openapi3['Argument']> = true
     expect(same).toBe(true)

--- a/test/paths.ts
+++ b/test/paths.ts
@@ -9,7 +9,7 @@ export type Data = {
 type Query = {
   parameters: {
     path: { a: number; b: string }
-    query: { scalar: string; list: string[] }
+    query: { scalar: string; list: string[]; optional?: string }
   }
   responses: { 200: { schema: Data } }
 }
@@ -33,7 +33,7 @@ type BodyArray = {
 type BodyAndQuery = {
   parameters: {
     path: { id: number }
-    query: { scalar: string }
+    query: { scalar: string; optional?: string }
     body: { payload: { list: string[] } }
   }
   responses: { 201: { schema: Data } }


### PR DESCRIPTION
In cases where a non-GET request has optional query params, the `.create()` function incorrectly allow you to omit them. This runtime code _must_ be present so the library can distinguish between body and query parameters, even if the actual call omits the optional param